### PR TITLE
Fix bug with SQLGetData

### DIFF
--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -322,19 +322,17 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
     static_cast<SqlLen>(bytesRequired - totalBytesWritten) : bytesRequired;
   LOG_DEBUG_MSG("remainingBytesRequired is " << remainingBytesRequired);
 
-  if ((currentCellOffset + buflen) < bytesRequired) {
-    SetCellOffset(currentCellOffset + (buflen / outCharSize));
-  } else {
-    SetCellOffset(totalBytesWritten);
-  }
-
   if (resLenPtr) {
     *resLenPtr = remainingBytesRequired;
   }
-  
+
   if (isTruncated) {
-      return ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED;
+    SetCellOffset(currentCellOffset + (buflen / outCharSize));
+    return ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED;
   } else {
+    if (cellOffset >= 0) {
+      SetCellOffset(totalBytesWritten);
+    }
     return ConversionResult::Type::AI_SUCCESS;
   }
 }

--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -270,13 +270,13 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
   SqlLen* resLenPtr = GetResLen();
   void* dataPtr = GetData();
 
-   if (!dataPtr) {
-     // Provide the total bytes required for the field.
-     if (resLenPtr) {
-       *resLenPtr = bytesRequired;
-     }
-     return ConversionResult::Type::AI_SUCCESS;
-   }
+  if (!dataPtr) {
+    // Provide the total bytes required for the field.
+    if (resLenPtr) {
+      *resLenPtr = bytesRequired;
+    }
+    return ConversionResult::Type::AI_SUCCESS;
+  }
 
   SqlUlen currentCellOffset = cellOffset >= 0 ? cellOffset : 0;
 

--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -325,7 +325,7 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
   }
 
   if (isTruncated) {
-    SetCellOffset(currentCellOffset + (buflen / outCharSize));
+    SetCellOffset(currentCellOffset + ((buflen / outCharSize) - 1));
     return ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED;
   } else {
     if (cellOffset >= 0) {

--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -283,7 +283,7 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
 
   if (inCharIndex >= value.length()) {
     if (resLenPtr) {
-      *resLenPtr = SQL_NO_TOTAL;
+      *resLenPtr = 0;
     }
     return ConversionResult::Type::AI_NO_DATA;
   }

--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -282,8 +282,8 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
   SqlUlen inCharIndex = currentCellOffset / inCharSize;
 
   if (inCharIndex >= value.length()) {
-    if (resLenPtr) {
-      *resLenPtr = 0;
+    if (resLenPtr && value.length() != 0) {
+      *resLenPtr = SQL_NO_TOTAL;
     }
     return ConversionResult::Type::AI_NO_DATA;
   }

--- a/src/odbc/src/connection.cpp
+++ b/src/odbc/src/connection.cpp
@@ -476,6 +476,11 @@ SqlResult::Type Connection::InternalSetAttribute(int attr, void* value,
       LOG_INFO_MSG("log level is set to " << static_cast< int >(type));
       break;
     }
+
+    case SQL_LOGIN_TIMEOUT: {
+      LOG_INFO_MSG("login timeout is not implemented yet and this value is ignored.");
+      break;
+    }
     default: {
       AddStatusRecord(SqlState::SHYC00_OPTIONAL_FEATURE_NOT_IMPLEMENTED,
                       "Specified attribute is not supported.");

--- a/src/tests/integration-test/src/api_robustness_test.cpp
+++ b/src/tests/integration-test/src/api_robustness_test.cpp
@@ -876,9 +876,6 @@ BOOST_AUTO_TEST_CASE(TestSQLGetData) {
 }
 
 BOOST_AUTO_TEST_CASE(TestSQLGetDataEmpty) {
-  // There are no checks because we do not really care what is the result of
-  // these calls as long as they do not cause segmentation fault.
-
   ConnectToTS();
 
   std::vector< SQLWCHAR > sql =
@@ -898,8 +895,6 @@ BOOST_AUTO_TEST_CASE(TestSQLGetDataEmpty) {
   ret = SQLGetData(stmt, 1, SQL_C_WCHAR, buffer, sizeof(buffer), &resLen);
   // Empty response should set resLen to 0
   BOOST_CHECK(resLen == 0);
-
-  // stmt, colNum, targetType, targetValue, bufferLength, strLengthOrIndicator
 
   ret = SQLGetData(stmt, 1, SQL_C_WCHAR, buffer, sizeof(buffer), &resLen);
   // Follow up calls to SQLGetData should return SQL_NO_DATA

--- a/src/tests/integration-test/src/api_robustness_test.cpp
+++ b/src/tests/integration-test/src/api_robustness_test.cpp
@@ -875,6 +875,37 @@ BOOST_AUTO_TEST_CASE(TestSQLGetData) {
   SQLFetch(stmt);
 }
 
+BOOST_AUTO_TEST_CASE(TestSQLGetDataEmpty) {
+  // There are no checks because we do not really care what is the result of
+  // these calls as long as they do not cause segmentation fault.
+
+  ConnectToTS();
+
+  std::vector< SQLWCHAR > sql =
+      MakeSqlBuffer("select ''");
+
+  SQLRETURN ret = SQLExecDirect(stmt, sql.data(), SQL_NTS);
+
+  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
+
+  ret = SQLFetch(stmt);
+
+  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
+
+  SQLWCHAR buffer[ODBC_BUFFER_SIZE];
+  SQLLEN resLen = 0;
+
+  ret = SQLGetData(stmt, 1, SQL_C_WCHAR, buffer, sizeof(buffer), &resLen);
+  // Empty response should set resLen to 0
+  BOOST_CHECK(resLen == 0);
+
+  // stmt, colNum, targetType, targetValue, bufferLength, strLengthOrIndicator
+
+  ret = SQLGetData(stmt, 1, SQL_C_WCHAR, buffer, sizeof(buffer), &resLen);
+  // Follow up calls to SQLGetData should return SQL_NO_DATA
+  BOOST_CHECK_EQUAL(ret, SQL_NO_DATA);
+}
+
 BOOST_AUTO_TEST_CASE(TestSQLGetDataVarcharAsciiZeroBufferLength) {
   // Ensures that calling SQLGetData with a buffer length of zero
   // returns the required amount of data in the indicator pointer.

--- a/src/tests/integration-test/src/api_robustness_test.cpp
+++ b/src/tests/integration-test/src/api_robustness_test.cpp
@@ -315,25 +315,6 @@ BOOST_AUTO_TEST_CASE(TestSQLFetchPastEnd) {
   SQLCloseCursor(stmt);
 }
 
-BOOST_AUTO_TEST_CASE(TestSQLFetchEmpty) {
-  // Ensures that an empty response returns SQL_NO_DATA
-  ConnectToTS();
-
-  std::vector<SQLWCHAR> sql = MakeSqlBuffer("SELECT ''");
-  SQLRETURN ret = SQLExecDirect(stmt, sql.data(), SQL_NTS);
-  // Expect success
-  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
-
-  // The first fetch should succeed
-  ret = SQLFetch(stmt);
-  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
-
-  ret = SQLFetch(stmt);
-  BOOST_CHECK_EQUAL(ret, SQL_NO_DATA);
-
-  SQLCloseCursor(stmt);
-}
-
 BOOST_AUTO_TEST_CASE(TestSQLExtendedFetch) {
   // There are no checks because we do not really care what is the result of
   // these calls as long as they do not cause segmentation fault.

--- a/src/tests/integration-test/src/api_robustness_test.cpp
+++ b/src/tests/integration-test/src/api_robustness_test.cpp
@@ -315,6 +315,25 @@ BOOST_AUTO_TEST_CASE(TestSQLFetchPastEnd) {
   SQLCloseCursor(stmt);
 }
 
+BOOST_AUTO_TEST_CASE(TestSQLFetchEmpty) {
+  // Ensures that an empty response returns SQL_NO_DATA
+  ConnectToTS();
+
+  std::vector<SQLWCHAR> sql = MakeSqlBuffer("SELECT ''");
+  SQLRETURN ret = SQLExecDirect(stmt, sql.data(), SQL_NTS);
+  // Expect success
+  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
+
+  // The first fetch should succeed
+  ret = SQLFetch(stmt);
+  ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
+
+  ret = SQLFetch(stmt);
+  BOOST_CHECK_EQUAL(ret, SQL_NO_DATA);
+
+  SQLCloseCursor(stmt);
+}
+
 BOOST_AUTO_TEST_CASE(TestSQLExtendedFetch) {
   // There are no checks because we do not really care what is the result of
   // these calls as long as they do not cause segmentation fault.

--- a/src/tests/integration-test/src/application_data_buffer_test.cpp
+++ b/src/tests/integration-test/src/application_data_buffer_test.cpp
@@ -1550,6 +1550,7 @@ BOOST_AUTO_TEST_CASE(TestSetStringWithOffset) {
   BOOST_CHECK(buf[1].reslen == strlen("Hello with offset!"));
 }
 
+
 BOOST_AUTO_TEST_CASE(TestSetLongString) {
   char buffer[1024];
   SqlLen reslen = 0;
@@ -1578,13 +1579,13 @@ BOOST_AUTO_TEST_CASE(TestSetLongString) {
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
   ret = appBuf.PutString(longString);
-  BOOST_CHECK_EQUAL(reslen, longString.size() - 2047);
-  BOOST_CHECK(!longString.substr(1024, 1023).compare(buffer));
+  BOOST_CHECK_EQUAL(reslen, longString.size() - 2046);
+  BOOST_CHECK(!longString.substr(1023, 1023).compare(buffer));
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
   ret = appBuf.PutString(longString);
   BOOST_CHECK(ConversionResult::Type::AI_SUCCESS == ret);
-  BOOST_CHECK(!longString.substr(2048).compare(buffer));
+  BOOST_CHECK(!longString.substr(2046).compare(buffer));
   BOOST_CHECK_EQUAL(reslen, 2080);
 
   ret = appBuf.PutString(longString);
@@ -1624,14 +1625,14 @@ BOOST_AUTO_TEST_CASE(TestSetLongStringWchar) {
   ret = appBuf.PutString(longString);
   converted_str = converter.to_bytes(buffer);
 
-  BOOST_CHECK(!longString.substr(1024, 1023).compare(converted_str));
-  BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), longString.size() - 2047);
+  BOOST_CHECK(!longString.substr(1023, 1023).compare(converted_str));
+  BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), longString.size() - 2046);
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
   ret = appBuf.PutString(longString);
   converted_str = converter.to_bytes(buffer);
 
-  BOOST_CHECK(!longString.substr(2048).compare(converted_str));
+  BOOST_CHECK(!longString.substr(2046).compare(converted_str));
   BOOST_CHECK(ConversionResult::Type::AI_SUCCESS == ret);
   BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), longString.size());
 

--- a/src/tests/integration-test/src/application_data_buffer_test.cpp
+++ b/src/tests/integration-test/src/application_data_buffer_test.cpp
@@ -1557,7 +1557,7 @@ BOOST_AUTO_TEST_CASE(TestSetLongString) {
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_CHAR, buffer, sizeof(buffer),
                                &reslen);
 
-  std::string bigString("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus cursus urna in nibh congue, at semper sapien efficitur. \
+  std::string longString("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus cursus urna in nibh congue, at semper sapien efficitur. \
       Cras eget velit at eros pharetra tempus. Sed laoreet lorem nunc, a congue orci euismod vel. Cras molestie tellus vitae nisl pretium, a tristique magna \
       tristique. In feugiat leo ac augue elementum facilisis. Pellentesque sollicitudin fringilla felis, id ornare mi lobortis a. Cras id eros vel nisi \
       condimentum elementum sed eget tellus. Pellentesque commodo augue vitae diam suscipit dictum. Quisque vulputate a nulla dignissim semper. Cras rhoncus \
@@ -1572,20 +1572,22 @@ BOOST_AUTO_TEST_CASE(TestSetLongString) {
       libero, ac semper est. Fusce non mattis lorem. Sed finibus leo egestas finibus euismod. Maecenas quis mauris vitae lacus efficitur mollis. Fusce faucibus \
       fermentum mauris, vitae vestibulum ligula aliquam in. Proin ut eu.");
 
-  ConversionResult::Type ret = appBuf.PutString(bigString);
-  BOOST_CHECK(!bigString.substr(0, 1023).compare(buffer));
-  BOOST_CHECK_EQUAL(reslen, SQL_NO_TOTAL);
+  ConversionResult::Type ret = appBuf.PutString(longString);
+  BOOST_CHECK(!longString.substr(0, 1023).compare(buffer));
+  BOOST_CHECK_EQUAL(reslen, longString.size() - 1023);
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
-  ret = appBuf.PutString(bigString);
-  BOOST_CHECK_EQUAL(reslen, SQL_NO_TOTAL);
-  BOOST_CHECK(!bigString.substr(1024, 1023).compare(buffer));
+  ret = appBuf.PutString(longString);
+  BOOST_CHECK_EQUAL(reslen, longString.size() - 2047);
+  BOOST_CHECK(!longString.substr(1024, 1023).compare(buffer));
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
-  ret = appBuf.PutString(bigString);
+  ret = appBuf.PutString(longString);
   BOOST_CHECK(ConversionResult::Type::AI_SUCCESS == ret);
-  BOOST_CHECK_EQUAL(reslen, bigString.size());
-  ret = appBuf.PutString(bigString);
+  BOOST_CHECK(!longString.substr(2048).compare(buffer));
+  BOOST_CHECK_EQUAL(reslen, 2080);
+
+  ret = appBuf.PutString(longString);
   BOOST_CHECK(ConversionResult::Type::AI_NO_DATA == ret);
 }
 
@@ -1596,7 +1598,7 @@ BOOST_AUTO_TEST_CASE(TestSetLongStringWchar) {
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer, sizeof(buffer),
                                &reslen);
 
-  std::string bigString("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus cursus urna in nibh congue, at semper sapien efficitur. \
+  std::string longString("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus cursus urna in nibh congue, at semper sapien efficitur. \
       Cras eget velit at eros pharetra tempus. Sed laoreet lorem nunc, a congue orci euismod vel. Cras molestie tellus vitae nisl pretium, a tristique magna \
       tristique. In feugiat leo ac augue elementum facilisis. Pellentesque sollicitudin fringilla felis, id ornare mi lobortis a. Cras id eros vel nisi \
       condimentum elementum sed eget tellus. Pellentesque commodo augue vitae diam suscipit dictum. Quisque vulputate a nulla dignissim semper. Cras rhoncus \
@@ -1611,28 +1613,29 @@ BOOST_AUTO_TEST_CASE(TestSetLongStringWchar) {
       libero, ac semper est. Fusce non mattis lorem. Sed finibus leo egestas finibus euismod. Maecenas quis mauris vitae lacus efficitur mollis. Fusce faucibus \
       fermentum mauris, vitae vestibulum ligula aliquam in. Proin ut eu.");
 
-  ConversionResult::Type ret = appBuf.PutString(bigString);
-
+  ConversionResult::Type ret = appBuf.PutString(longString);
   std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
   std::string converted_str = converter.to_bytes(buffer);
 
-  BOOST_CHECK(!bigString.substr(0, 1023).compare(converted_str));
-  BOOST_CHECK_EQUAL(reslen, SQL_NO_TOTAL);
+  BOOST_CHECK(!longString.substr(0, 1023).compare(converted_str));
+  BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), longString.size() - 1023);
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
-  ret = appBuf.PutString(bigString);
-  BOOST_CHECK_EQUAL(reslen, SQL_NO_TOTAL);
-
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter2;
+  ret = appBuf.PutString(longString);
   converted_str = converter.to_bytes(buffer);
 
-  BOOST_CHECK(!bigString.substr(1024, 1023).compare(converted_str));
+  BOOST_CHECK(!longString.substr(1024, 1023).compare(converted_str));
+  BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), longString.size() - 2047);
   BOOST_CHECK(ConversionResult::Type::AI_VARLEN_DATA_TRUNCATED == ret);
 
-  ret = appBuf.PutString(bigString);
+  ret = appBuf.PutString(longString);
+  converted_str = converter.to_bytes(buffer);
+
+  BOOST_CHECK(!longString.substr(2048).compare(converted_str));
   BOOST_CHECK(ConversionResult::Type::AI_SUCCESS == ret);
-  BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), bigString.size());
-  ret = appBuf.PutString(bigString);
+  BOOST_CHECK_EQUAL(reslen / sizeof(wchar_t), longString.size());
+
+  ret = appBuf.PutString(longString);
   BOOST_CHECK(ConversionResult::Type::AI_NO_DATA == ret);
 }
 


### PR DESCRIPTION
### Summary

SQLGetData was returning SQL_NO_TOTAL which cause PowerBI ODBC and custom connection failures when data returned is empty or finished reading data.

### Description

To align with [SQLGetData function](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function?view=sql-server-ver16#retrieving-data-with-sqlgetdata), SQL_NO_TOTAL should be set only when response size is unknown. The login timeout will be handled in follow up work and for now the value is ignored.

### Related Issue

[Issue 19](https://github.com/awslabs/amazon-timestream-odbc-driver/issues/19)

### Validations
- [x] IT tests pass
- [x] UT tests pass
- [x] Direct query with PowerBI custom connector
- [x] Import with PowerBI and ODBC
- [x] Tested C# application using OdbcConnection on MSDN
```
using System.Diagnostics;
using System;
using System.Data.Odbc;

class Program { 
    
    static void Main(string[] args) { 
        
        Debug.Listeners.Add(new ConsoleTraceListener());
        string queryString = "SELECT * FROM data_queries_test_db.TestComplexTypes";

        using (OdbcConnection connection = new OdbcConnection("DSN=Timestream DSN;"))
        {
            OdbcCommand command = new OdbcCommand(queryString, connection);
            connection.Open();
            // Execute the DataReader and access the data.
            OdbcDataReader reader = command.ExecuteReader();
            while (reader.Read())
            {
                Debug.WriteLine("{0}", reader[0]);
            }
            reader.Close();
        }
        Console.ReadLine();
    } 
} 
```
**Compile code**:
```
csc  /define:DEBUG .\odbcTest.cs
```


- [x] Tested ADODB powershell script query
```
# Define the connection string using the MSDASQL provider for ODBC
# Replace 'YourDSN' with your Data Source Name configured in ODBC Data Source Administrator

$connectionString = "DSN=Timestream DSN;logLevel=4;"
$query = "SELECT * FROM data_queries_test_db.TestComplexTypes"

# ------------------- OLE DB -------------------
$connection = New-Object -ComObject ADODB.Connection
$connection.Open($connectionString)

Write-Host -NoNewline 'Press any key to continue . . .';
$null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown');

# Create the command object
$command = New-Object -ComObject ADODB.Command
$command.ActiveConnection = $connection
$command.CommandText = $query

# Execute the query
$recordset = $command.Execute()

# Loop through results and display them
if ($recordset) {
	while (!$recordset.EOF) {
		$rowData = ""
		for ($i = 0; $i -lt $recordset.Fields.Count; $i++) {
			$field = $recordset.Fields.Item($i)
			$fieldValue = $field.Value
			if ($fieldValue -is [System.DBNull]) {
				$fieldValue = "-"
			}
			$rowData += "$($field.Name): $($fieldValue)"
			if ($i -lt $recordset.Fields.Count - 1) {
				$rowData += " | "
			}
		}
		Write-Output $rowData
		Write-Output ""
    	$recordset.MoveNext()
	}
	$recordset.Close()
}

$connection.Close()

```
- [x] Test with Excel using OLE DB
![Screenshot 2024-09-11 at 2 21 08 PM](https://github.com/user-attachments/assets/59be78f8-1f8d-424d-a1be-ed70a43ecbb6)
