### PR TITLE
Fix Double Conversion in `ApplicationDataBuffer`

### DIFF
--- a/src/odbc/include/timestream/odbc/utility.h
+++ b/src/odbc/include/timestream/odbc/utility.h
@@ -98,7 +98,8 @@ CopyUtf8StringToSqlWcharString(const char* inBuffer, SQLWCHAR* outBuffer,
  * @return isTruncated Reference to indicator of whether the input string was
  * truncated in the output buffer.
  * return value(bytes):
- *   - 0, if the inBuffer or outBufferLenBytes is nullptr or outBufferLenBytes is 0
+ *   - 0, if the inBuffer or outBufferLenBytes is nullptr or outBufferLenBytes is
+ * less than size of SQLWCHAR in bytes
  *   - copied bytes number, if outBuffer is not nullptr and outBufferLenBytes
  *   is not 0
  */

--- a/src/odbc/include/timestream/odbc/utility.h
+++ b/src/odbc/include/timestream/odbc/utility.h
@@ -90,6 +90,23 @@ CopyUtf8StringToSqlWcharString(const char* inBuffer, SQLWCHAR* outBuffer,
                                size_t outBufferLenBytes, bool& isTruncated);
 
 /**
+ * Copy wstring to SQLWCHAR buffer of the specific length. It will ensure
+ * null terminated result, possibly truncated.
+ * @param inBuffer null-terminated wstring to copy data from.
+ * @param outBuffer SQLWCHAR buffer to copy data to.
+ * @param outBufferLenBytes Length of the output buffer, in bytes.
+ * @return isTruncated Reference to indicator of whether the input string was
+ * truncated in the output buffer.
+ * return value(bytes):
+ *   - 0, if the inBuffer or outBufferLenBytes is nullptr or outBufferLenBytes is 0
+ *   - copied bytes number, if outBuffer is not nullptr and outBufferLenBytes
+ *   is not 0
+ */
+IGNITE_IMPORT_EXPORT size_t
+CopyWcharStringToSqlWcharString(const wchar_t* inBuffer, SQLWCHAR* outBuffer,
+                                size_t outBufferLenBytes, bool& isTruncated);
+
+/**
  * Copy string to buffer of the specific length.
  * @param str String to copy data from.
  * @param buf Buffer to copy data to.

--- a/src/odbc/src/app/application_data_buffer.cpp
+++ b/src/odbc/src/app/application_data_buffer.cpp
@@ -257,13 +257,14 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
                                  << outCharSize << ", buflen is " << buflen);
 
   size_t bytesRequired = 0;
+  std::wstring convertedString;
   if (ANSI_STRING_ONLY) {
     bytesRequired = value.length() * outCharSize;
   } else {
     thread_local std::wstring_convert<std::codecvt_utf8<wchar_t >, wchar_t>
       converter;
-    std::wstring inString = converter.from_bytes(value.c_str());
-    bytesRequired = inString.length() * outCharSize;
+    convertedString = converter.from_bytes(value.c_str());
+    bytesRequired = convertedString.length() * outCharSize;
   }
 
   SqlLen* resLenPtr = GetResLen();
@@ -290,9 +291,9 @@ ConversionResult::Type ApplicationDataBuffer::PutStrToStrBuffer(
   bool isTruncated = false;
   if (inCharSize == 1) {
     if (outCharSize == 2 || outCharSize == 4) {
-      bytesWritten = utility::CopyUtf8StringToSqlWcharString(
-          reinterpret_cast< const char* >(value.c_str() + currentCellOffset),
-          reinterpret_cast< SQLWCHAR* >(dataPtr), buflen, isTruncated);
+      bytesWritten = utility::CopyWcharStringToSqlWcharString(
+          convertedString.c_str() + currentCellOffset,
+          reinterpret_cast<SQLWCHAR*>(dataPtr), buflen, isTruncated);
     } else if (sizeof(OutCharT) == 1) {
       bytesWritten = utility::CopyUtf8StringToSqlCharString(
           reinterpret_cast< const char* >(value.c_str() + currentCellOffset),

--- a/src/odbc/src/utility.cpp
+++ b/src/odbc/src/utility.cpp
@@ -215,6 +215,46 @@ size_t CopyUtf8StringToSqlWcharString(const char* inBuffer, SQLWCHAR* outBuffer,
   }
 }
 
+size_t CopyWcharStringToSqlWcharString(const wchar_t* inBuffer, SQLWCHAR* outBuffer,
+                                       size_t outBufferLenBytes, bool& isTruncated) {
+    LOG_DEBUG_MSG(
+        "CopyWStringToSqlWcharString called with outBufferLenBytes = "
+        << outBufferLenBytes);
+
+    // Validate input parameters
+    if (!inBuffer || !outBuffer || outBufferLenBytes < sizeof(SQLWCHAR)) {
+      return 0;
+    }
+
+    const size_t sqlWcharSize = sizeof(SQLWCHAR);
+     // Reserve space for null terminator
+    const size_t maxChars = (outBufferLenBytes / sqlWcharSize) - 1;
+
+    // determine the length up to maxChars + 1 to check for truncation
+    size_t inLength = wcsnlen(inBuffer, maxChars + 1);
+
+    // Check if truncation is needed
+    if (inLength > maxChars) {
+      isTruncated = true;
+      inLength = maxChars;
+      LOG_DEBUG_MSG("Truncation required. Adjusted input length to " << inLength);
+    } else {
+      LOG_DEBUG_MSG("No truncation required. Input length = " << inLength);
+    }
+
+    // Perform the copy using wmemcpy for efficiency
+    wmemcpy(outBuffer, inBuffer, inLength);
+
+    // Null-terminate the output buffer
+    outBuffer[inLength] = 0;
+
+    const size_t bytesWritten = inLength * sqlWcharSize;
+    LOG_DEBUG_MSG("Bytes written (excluding null terminator) = " << bytesWritten);
+    LOG_DEBUG_MSG("Truncation flag = " << (isTruncated ? "true" : "false"));
+
+    return bytesWritten;
+}
+
 // High-level entry point to handle buffer size in either bytes or characters
 size_t CopyStringToBuffer(const std::string& str, SQLWCHAR* buf, size_t buflen,
                           bool& isTruncated, bool isLenInBytes) {

--- a/src/odbc/src/utility.cpp
+++ b/src/odbc/src/utility.cpp
@@ -218,15 +218,14 @@ size_t CopyUtf8StringToSqlWcharString(const char* inBuffer, SQLWCHAR* outBuffer,
 size_t CopyWcharStringToSqlWcharString(const wchar_t* inBuffer, SQLWCHAR* outBuffer,
                                        size_t outBufferLenBytes, bool& isTruncated) {
     LOG_DEBUG_MSG(
-        "CopyWStringToSqlWcharString called with outBufferLenBytes = "
+        "CopyWcharStringToSqlWcharString called with outBufferLenBytes = "
         << outBufferLenBytes);
 
-    // Validate input parameters
-    if (!inBuffer || !outBuffer || outBufferLenBytes < sizeof(SQLWCHAR)) {
+    const size_t sqlWcharSize = sizeof(SQLWCHAR);
+    if (!inBuffer || !outBuffer || outBufferLenBytes < sqlWcharSize) {
       return 0;
     }
 
-    const size_t sqlWcharSize = sizeof(SQLWCHAR);
      // Reserve space for null terminator
     const size_t maxChars = (outBufferLenBytes / sqlWcharSize) - 1;
 

--- a/src/tests/unit-test/src/utility_test.cpp
+++ b/src/tests/unit-test/src/utility_test.cpp
@@ -174,4 +174,67 @@ BOOST_AUTO_TEST_CASE(TestUtilitySqlStringToString) {
   BOOST_CHECK_EQUAL(utf8StringShortened, result);
 }
 
+BOOST_AUTO_TEST_CASE(TestCopyWcharStringToSqlWcharString) {
+    // Normal Copy
+    {
+        const wchar_t* inBuffer = L"Hello, World!";
+        SQLWCHAR outBuffer[50] = {0};
+        bool isTruncated = false;
+        size_t bytesWritten = CopyWcharStringToSqlWcharString(inBuffer, outBuffer, sizeof(outBuffer), isTruncated);
+        BOOST_CHECK(!isTruncated);
+        BOOST_CHECK_EQUAL(bytesWritten, wcslen(inBuffer) * sizeof(SQLWCHAR));
+        BOOST_CHECK_EQUAL(std::wstring(reinterpret_cast<wchar_t*>(outBuffer)), std::wstring(inBuffer));
+    }
+
+    // Exact Fit
+    {
+        const wchar_t* inBuffer = L"ExactFit";
+        size_t inLength = wcslen(inBuffer);
+        size_t outBufferLenBytes = (inLength + 1) * sizeof(SQLWCHAR); // Exact fit including null terminator
+        SQLWCHAR outBuffer[9] = {0}; // 8 characters + null terminator
+        bool isTruncated = false;
+        size_t bytesWritten = CopyWcharStringToSqlWcharString(inBuffer, outBuffer, outBufferLenBytes, isTruncated);
+        BOOST_CHECK(!isTruncated);
+        BOOST_CHECK_EQUAL(bytesWritten, inLength * sizeof(SQLWCHAR));
+        BOOST_CHECK_EQUAL(std::wstring(reinterpret_cast<wchar_t*>(outBuffer)), std::wstring(inBuffer));
+    }
+
+    // Truncation
+    {
+        const wchar_t* inBuffer = L"TruncatedString";
+        size_t maxChars = 5; // Intentionally small to force truncation
+        size_t outBufferLenBytes = (maxChars + 1) * sizeof(SQLWCHAR); // 5 characters + null terminator
+        SQLWCHAR outBuffer[6] = {0};
+        bool isTruncated = false;
+        size_t bytesWritten = CopyWcharStringToSqlWcharString(inBuffer, outBuffer, outBufferLenBytes, isTruncated);
+        BOOST_CHECK(isTruncated);
+        BOOST_CHECK_EQUAL(bytesWritten, maxChars * sizeof(SQLWCHAR));
+        std::wstring expected(inBuffer, maxChars);
+        BOOST_CHECK_EQUAL(std::wstring(reinterpret_cast<wchar_t*>(outBuffer)), expected);
+    }
+
+    // Null Input Buffer
+    {
+        SQLWCHAR outBuffer[10] = {0};
+        bool isTruncated = false;
+        size_t bytesWritten = CopyWcharStringToSqlWcharString(nullptr, outBuffer, sizeof(outBuffer), isTruncated);
+        BOOST_CHECK_EQUAL(bytesWritten, 0);
+        // Here we check that the first element is untouched (still 0)
+        BOOST_CHECK_EQUAL(outBuffer[0], static_cast<SQLWCHAR>(0));
+    }
+
+    // Empty Input String
+    {
+        const wchar_t* inBuffer = L"";
+        SQLWCHAR outBuffer[10] = {0};
+        bool isTruncated = false;
+        size_t bytesWritten = CopyWcharStringToSqlWcharString(inBuffer, outBuffer, sizeof(outBuffer), isTruncated);
+        BOOST_CHECK(!isTruncated);
+        BOOST_CHECK_EQUAL(bytesWritten, 0);
+        BOOST_CHECK_EQUAL(outBuffer[0], static_cast<SQLWCHAR>(0));
+    }
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
### Summary

The `ApplicationDataBuffer` class performs a double conversion when loading a string into a buffer.

### Description

Introduced a new utility function that copies a wstring to a SQLWCHAR buffer. Added some basic unit tests and removed the double conversion.

- [x] Unit tests passed
- [x] IT tests passed
- [x] Test with Excel
![Screenshot 2025-01-17 at 11 17 13 AM](https://github.com/user-attachments/assets/ae223ddd-8d70-4236-a705-1baea5147572)

### Related Issue

N/A

### Additional Reviewers

N/A
